### PR TITLE
Solved a bug where the PauseLayer was capturing all gui_input events

### DIFF
--- a/scenes/gameplay/pause-layer/pause-layer.tscn
+++ b/scenes/gameplay/pause-layer/pause-layer.tscn
@@ -12,6 +12,7 @@ script = ExtResource("2")
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
+mouse_filter = 2
 color = Color(0.243137, 0.211765, 0.290196, 0.717647)
 
 [node name="MarginContainer" type="MarginContainer" parent="."]
@@ -20,9 +21,11 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
+mouse_filter = 2
 
 [node name="Control" type="Control" parent="MarginContainer"]
 layout_mode = 2
+mouse_filter = 2
 
 [node name="PauseButton" type="TextureButton" parent="MarginContainer/Control"]
 layout_mode = 1
@@ -46,6 +49,7 @@ offset_right = 58.0
 offset_bottom = 38.0
 grow_horizontal = 2
 grow_vertical = 2
+mouse_filter = 2
 theme_override_constants/separation = 20
 
 [node name="Resume" type="LinkButton" parent="MarginContainer/Control/VBoxOptions"]

--- a/scenes/gameplay/pause-layer/pause-layer.tscn
+++ b/scenes/gameplay/pause-layer/pause-layer.tscn
@@ -32,6 +32,7 @@ layout_mode = 1
 offset_right = 42.0
 offset_bottom = 42.0
 size_flags_horizontal = 0
+mouse_filter = 1
 texture_normal = ExtResource("4")
 ignore_texture_size = true
 stretch_mode = 0
@@ -55,11 +56,13 @@ theme_override_constants/separation = 20
 [node name="Resume" type="LinkButton" parent="MarginContainer/Control/VBoxOptions"]
 layout_mode = 2
 focus_mode = 2
+mouse_filter = 1
 text = "RESUME"
 
 [node name="MainMenu" type="LinkButton" parent="MarginContainer/Control/VBoxOptions"]
 layout_mode = 2
 focus_mode = 2
+mouse_filter = 1
 text = "MAIN MENU"
 
 [node name="Label" type="Label" parent="MarginContainer/Control"]


### PR DESCRIPTION
The PauseLayer had its Control's mouse_filter flag set to Stop which caused Control nodes in the gameplay scene from receiving gui_input events. This resolves it by setting them to Ignore and the buttons and links to Pass. This resolves #97 