### PR TITLE
fix "Play Scene" compatibility

### DIFF
--- a/addons/ggt-core/scenes/scenes.gd
+++ b/addons/ggt-core/scenes/scenes.gd
@@ -31,6 +31,8 @@ func _ready():
 	# if playing a specific scene
 	if ProjectSettings.get("application/run/main_scene") != cur_scene.scene_file_path:
 		# call pre_start and start method to ensure compatibility with "Play Scene"
+		if not cur_scene.is_node_ready():
+			await cur_scene.ready
 		if cur_scene.has_method("pre_start"):
 			cur_scene.pre_start({})
 		if cur_scene.has_method("start"):

--- a/scenes/gameplay/gameplay.gd
+++ b/scenes/gameplay/gameplay.gd
@@ -2,6 +2,7 @@ extends Node
 
 var elapsed = 0
 
+@onready var sprite_2d: Sprite2D = $Sprite2D
 
 # `pre_start()` is called when a scene is loaded.
 # Use this function to receive params from `Game.change_scene(params)`.
@@ -12,7 +13,7 @@ func pre_start(params):
 		for key in params:
 			var val = params[key]
 			printt("", key, val)
-	$Sprite2D.position = Game.size / 2
+	sprite_2d.position = Game.size / 2
 
 
 # `start()` is called after pre_start and after the graphic transition ends.
@@ -22,5 +23,5 @@ func start():
 
 func _process(delta):
 	elapsed += delta
-	$Sprite2D.position.x = Game.size.x / 2 + 150 * sin(2 * 0.4 * PI * elapsed)
-	$Sprite2D.position.y = Game.size.y / 2 + 100 * sin(2 * 0.2 * PI * elapsed)
+	sprite_2d.position.x = Game.size.x / 2 + 150 * sin(2 * 0.4 * PI * elapsed)
+	sprite_2d.position.y = Game.size.y / 2 + 100 * sin(2 * 0.2 * PI * elapsed)


### PR DESCRIPTION
When launching a scene directly using "Play Scene", an error will occur if you try to access an `@onready` variable from `pre_start` or `start`.

Updated `scenes.gd` to ensure the scene is ready before calling `pre_start` and `start`. Updated `gameplay.gd` to use `@onready` variable to highlight the bug and fix.